### PR TITLE
Allow root mount point

### DIFF
--- a/gst/rtsp-server/rtsp-client.c
+++ b/gst/rtsp-server/rtsp-client.c
@@ -3328,6 +3328,12 @@ sanitize_uri (GstRTSPUrl * uri)
   s = d = uri->abspath;
   len = strlen (uri->abspath);
 
+  if (len == 0 || !strcmp(uri->abspath, "/stream=0")) {
+    g_free(uri->abspath);
+    uri->abspath = g_strdup("/");
+    return;
+  }
+
   prev_slash = FALSE;
 
   for (i = 0; i < len; i++) {


### PR DESCRIPTION
This fix enables rtsp server root mount point like this:
 gst_rtsp_mount_points_add_factory(_mounts, "/", _factory);
So that following URIs are possible:
rtsp://127.0.0.1:8554
rtsp://127.0.0.1:8554/