### PR TITLE
rtsp-server: Fix rtsp-media-factory handling of url.

### DIFF
--- a/gst/rtsp-server/rtsp-media-factory.c
+++ b/gst/rtsp-server/rtsp-media-factory.c
@@ -1421,14 +1421,11 @@ default_gen_key (GstRTSPMediaFactory * factory, const GstRTSPUrl * url)
   gchar *result;
   const gchar *pre_query;
   const gchar *query;
-  guint16 port;
 
   pre_query = url->query ? "?" : "";
   query = url->query ? url->query : "";
 
-  gst_rtsp_url_get_port (url, &port);
-
-  result = g_strdup_printf ("%u%s%s%s", port, url->abspath, pre_query, query);
+  result = g_strdup_printf ("%s%s%s", url->abspath, pre_query, query);
 
   return result;
 }


### PR DESCRIPTION
Patched per bomba_____:
https://gitlab.freedesktop.org/gstreamer/gst-rtsp-server/-/issues/21
to resolve
ERROR rtsp-client.c:1718:handle_play_request: [...] media not found