### PR TITLE
Feature/run rtspserver without gst pipeline

### DIFF
--- a/gst/rtsp-server/rtsp-media.c
+++ b/gst/rtsp-server/rtsp-media.c
@@ -2334,6 +2334,41 @@ appsrc_pad_probe (GstPad * pad, GstPadProbeInfo * info, gpointer user_data)
 }
 
 /**
+ * gst_rtsp_media_add_stream:
+ * @media: a #GstRTSPMedia
+ * @stream: (transfer full): a #GstRTSPStream
+ *
+ * Add a new stream in @media.
+ *
+ */
+void
+gst_rtsp_media_add_stream (GstRTSPMedia *media, GstRTSPStream * stream)
+{
+  GstRTSPMediaPrivate *priv;
+
+  g_return_if_fail (GST_IS_RTSP_STREAM (stream));
+
+  priv = media->priv;
+  g_mutex_lock (&priv->lock);
+
+  if (priv->pool)
+    gst_rtsp_stream_set_address_pool (stream, priv->pool);
+  gst_rtsp_stream_set_multicast_iface (stream, priv->multicast_iface);
+  gst_rtsp_stream_set_max_mcast_ttl (stream, priv->max_mcast_ttl);
+  gst_rtsp_stream_set_bind_mcast_address (stream, priv->bind_mcast_address);
+  gst_rtsp_stream_set_profiles (stream, priv->profiles);
+  gst_rtsp_stream_set_protocols (stream, priv->protocols);
+  gst_rtsp_stream_set_retransmission_time (stream, priv->rtx_time);
+  gst_rtsp_stream_set_buffer_size (stream, priv->buffer_size);
+  gst_rtsp_stream_set_publish_clock_mode (stream, priv->publish_clock_mode);
+  gst_rtsp_stream_set_rate_control (stream, priv->do_rate_control);
+
+  g_ptr_array_add (priv->streams, stream);
+  g_mutex_unlock (&priv->lock);
+}
+
+
+/**
  * gst_rtsp_media_create_stream:
  * @media: a #GstRTSPMedia
  * @payloader: a #GstElement

--- a/gst/rtsp-server/rtsp-media.c
+++ b/gst/rtsp-server/rtsp-media.c
@@ -3937,6 +3937,10 @@ gst_rtsp_media_prepare (GstRTSPMedia * media, GstRTSPThread * thread)
       goto prepare_failed;
   }
 
+  if (klass->is_live) {
+    priv->is_live = klass->is_live(media);
+  }
+
 wait_status:
   g_rec_mutex_unlock (&priv->state_lock);
 

--- a/gst/rtsp-server/rtsp-media.c
+++ b/gst/rtsp-server/rtsp-media.c
@@ -3136,11 +3136,13 @@ static GstStateChangeReturn
 set_state (GstRTSPMedia * media, GstState state)
 {
   GstRTSPMediaPrivate *priv = media->priv;
-  GstStateChangeReturn ret;
+  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
 
   GST_INFO ("set state to %s for media %p", gst_element_state_get_name (state),
       media);
-  ret = gst_element_set_state (priv->pipeline, state);
+
+  if (priv->pipeline)
+    ret = gst_element_set_state (priv->pipeline, state);
 
   return ret;
 }

--- a/gst/rtsp-server/rtsp-media.c
+++ b/gst/rtsp-server/rtsp-media.c
@@ -2784,7 +2784,7 @@ media_streams_set_blocked (GstRTSPMedia * media, gboolean blocked)
     priv->blocking_msg_received = 0;
 }
 
-static void
+void
 gst_rtsp_media_set_status (GstRTSPMedia * media, GstRTSPMediaStatus status)
 {
   GstRTSPMediaPrivate *priv = media->priv;

--- a/gst/rtsp-server/rtsp-media.c
+++ b/gst/rtsp-server/rtsp-media.c
@@ -4109,7 +4109,8 @@ gst_rtsp_media_unprepare (GstRTSPMedia * media)
   set_target_state (media, GST_STATE_NULL, FALSE);
   success = TRUE;
 
-  if (priv->status == GST_RTSP_MEDIA_STATUS_PREPARED) {
+  if (priv->status == GST_RTSP_MEDIA_STATUS_PREPARED ||
+      priv->status == GST_RTSP_MEDIA_STATUS_SUSPENDED) {
     GstRTSPMediaClass *klass;
 
     klass = GST_RTSP_MEDIA_GET_CLASS (media);

--- a/gst/rtsp-server/rtsp-media.c
+++ b/gst/rtsp-server/rtsp-media.c
@@ -1657,6 +1657,9 @@ update_stream_storage_size (GstRTSPMedia * media, GstRTSPStream * stream,
 {
   GObject *storage = NULL;
 
+  if (!media->priv->rtpbin)
+    return;
+
   g_signal_emit_by_name (G_OBJECT (media->priv->rtpbin), "get-storage",
       sessid, &storage);
 

--- a/gst/rtsp-server/rtsp-media.c
+++ b/gst/rtsp-server/rtsp-media.c
@@ -523,7 +523,8 @@ gst_rtsp_media_finalize (GObject * obj)
     gst_object_unref (priv->pipeline);
   if (priv->nettime)
     gst_object_unref (priv->nettime);
-  gst_object_unref (priv->element);
+  if (priv->element)
+    gst_object_unref (priv->element);
   if (priv->pool)
     g_object_unref (priv->pool);
   if (priv->payloads)
@@ -608,7 +609,9 @@ gst_rtsp_media_set_property (GObject * object, guint propid,
   switch (propid) {
     case PROP_ELEMENT:
       media->priv->element = g_value_get_object (value);
-      gst_object_ref_sink (media->priv->element);
+      if (media->priv->element) {
+        gst_object_ref_sink (media->priv->element);
+      }
       break;
     case PROP_SHARED:
       gst_rtsp_media_set_shared (media, g_value_get_boolean (value));

--- a/gst/rtsp-server/rtsp-media.h
+++ b/gst/rtsp-server/rtsp-media.h
@@ -209,6 +209,9 @@ GST_RTSP_SERVER_API
 GstRTSPMediaStatus    gst_rtsp_media_get_status       (GstRTSPMedia *media);
 
 GST_RTSP_SERVER_API
+void                  gst_rtsp_media_set_status       (GstRTSPMedia * media, GstRTSPMediaStatus status);
+
+GST_RTSP_SERVER_API
 void                  gst_rtsp_media_set_permissions  (GstRTSPMedia *media,
                                                        GstRTSPPermissions *permissions);
 

--- a/gst/rtsp-server/rtsp-media.h
+++ b/gst/rtsp-server/rtsp-media.h
@@ -365,6 +365,10 @@ GST_RTSP_SERVER_API
 void                  gst_rtsp_media_collect_streams  (GstRTSPMedia *media);
 
 GST_RTSP_SERVER_API
+void                  gst_rtsp_media_add_stream       (GstRTSPMedia *media,
+                                                       GstRTSPStream * stream);
+
+GST_RTSP_SERVER_API
 GstRTSPStream *       gst_rtsp_media_create_stream    (GstRTSPMedia *media,
                                                        GstElement *payloader,
                                                        GstPad *pad);

--- a/gst/rtsp-server/rtsp-media.h
+++ b/gst/rtsp-server/rtsp-media.h
@@ -174,6 +174,7 @@ struct _GstRTSPMediaClass {
   GstElement *    (*create_rtpbin)   (GstRTSPMedia *media);
   gboolean        (*setup_rtpbin)    (GstRTSPMedia *media, GstElement *rtpbin);
   gboolean        (*setup_sdp)       (GstRTSPMedia *media, GstSDPMessage *sdp, GstSDPInfo *info);
+  gboolean        (*is_live)         (GstRTSPMedia *media);
 
   /* signals */
   void            (*new_stream)      (GstRTSPMedia *media, GstRTSPStream * stream);

--- a/gst/rtsp-server/rtsp-stream.c
+++ b/gst/rtsp-server/rtsp-stream.c
@@ -427,7 +427,8 @@ gst_rtsp_stream_finalize (GObject * obj)
   g_free (priv->multicast_iface);
   g_list_free_full (priv->mcast_clients, (GDestroyNotify) free_mcast_client);
 
-  gst_object_unref (priv->payloader);
+  if (priv->payloader)
+    gst_object_unref (priv->payloader);
   if (priv->srcpad)
     gst_object_unref (priv->srcpad);
   if (priv->sinkpad)

--- a/gst/rtsp-server/rtsp-stream.c
+++ b/gst/rtsp-server/rtsp-stream.c
@@ -550,6 +550,23 @@ gst_rtsp_stream_new (guint idx, GstElement * payloader, GstPad * pad)
 }
 
 /**
+ * gst_rtsp_stream_set_index:
+ * @stream: a #GstRTSPStream
+ * @idx: the stream index
+ *
+ * Set the stream index.
+ *
+ */
+void
+gst_rtsp_stream_set_index (GstRTSPStream * stream, guint idx)
+{
+  g_return_if_fail (GST_IS_RTSP_STREAM (stream));
+
+  stream->priv->idx = idx;
+}
+
+
+/**
  * gst_rtsp_stream_get_index:
  * @stream: a #GstRTSPStream
  *

--- a/gst/rtsp-server/rtsp-stream.h
+++ b/gst/rtsp-server/rtsp-stream.h
@@ -81,6 +81,9 @@ GstRTSPStream *   gst_rtsp_stream_new              (guint idx, GstElement *paylo
                                                     GstPad *pad);
 
 GST_RTSP_SERVER_API
+void              gst_rtsp_stream_set_index        (GstRTSPStream *stream, guint idx);
+
+GST_RTSP_SERVER_API
 guint             gst_rtsp_stream_get_index        (GstRTSPStream *stream);
 
 GST_RTSP_SERVER_API

--- a/gst/rtsp-server/rtsp-stream.h
+++ b/gst/rtsp-server/rtsp-stream.h
@@ -63,6 +63,12 @@ struct _GstRTSPStream {
 struct _GstRTSPStreamClass {
   GObjectClass parent_class;
 
+  /* vmethods */
+  void            (*get_ssrc)          (GstRTSPStream *stream, guint *ssrc);
+  gboolean        (*complete_stream)   (GstRTSPStream *stream, const GstRTSPTransport *trans);
+  gboolean        (*add_transport)     (GstRTSPStream *stream, GstRTSPStreamTransport *trans);
+  gboolean        (*remove_transport)  (GstRTSPStream *stream, GstRTSPStreamTransport *trans);
+
   /*< private >*/
   gpointer _gst_reserved[GST_PADDING];
 };


### PR DESCRIPTION
Hi,


I'm currently working on a project where, for security reasons, the rtsp server should run in a different process then the actual gstreamer rtpbin process. Also, the rtpbin process should keep running even when all rtsp clients are disconnected.
I would like to use the gst-rtsp-server as a base for this rtsp server, however some adaptions are needed.

The main change which I have done so far is twofold:
* allow NULL pointer in rtsp-media/rtsp-stream that point to rtpbin/payloader/element/pipeline as they are all NULL in my case.
* Add virtual methods in rtsp-stream so I can make a derived type and have a custom implementation

I'm not asking to merge these things right away. This is still work in progress.


I would just want to have some feedback on these questions:
* Does this look like the right approach? Are other solutions possible?
* Are you planning to support a use case like this? (Where rtpbin/gst-pipeline runs in a seperate process)
* Are these changes (allow NULL pointer and add virtual methods) acceptable to be merged in?
    If they don't, I don't think I will proceed with this as I don't want to patch gst-rtsp-server on each new release.
* Another approach I thought of, is to create dummy rtpbin and payloader elements and insert those into a gstreamer pipeline. These dummy elements could act then as a proxy for the real elements in the other process. I started it, but turned out to be much more work then I initially thought. What do you think, would this be feasible?

